### PR TITLE
Improve `use` and stencil subscription.

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -7,6 +7,6 @@ export const createStore = <T extends { [key: string]: any }>(
   shouldUpdate?: (newV: any, oldValue, prop: keyof T) => boolean
 ): ObservableMap<T> => {
   const map = createObservableMap(defaultState, shouldUpdate);
-  stencilSubscription(map);
+  map.use(stencilSubscription());
   return map;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export interface OnChangeHandler<StoreType> {
 }
 
 export interface Subscription<StoreType> {
+  dispose?(): void;
   get?<KeyFromStoreType extends keyof StoreType>(key: KeyFromStoreType): void;
   set?<KeyFromStoreType extends keyof StoreType>(
     key: KeyFromStoreType,
@@ -110,5 +111,5 @@ export interface ObservableMap<T> {
    * Registers a subscription that will be called whenever the user gets, sets, or
    * resets a value.
    */
-  use(...plugins: Subscription<T>[]): void;
+  use(...plugins: Subscription<T>[]): () => void;
 }


### PR DESCRIPTION
This PR improves `use`, bringing it closer to `on` behaviour of returning an `unsubscribe` function.

This PR also modifies the stencil subscription to actually return a subscription.