### PR TITLE
Update readme to clarify when store updates a component

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Returns a `store` object with the following properties.
 
 #### `store.state`
 
-The state object is proxied, i. e. you can directly get and set properties and Store will automatically take care of component re-rendering when the state object is changed.
+The state object is proxied, i. e. you can directly get and set properties. If you access the state object in the `render` function of your component, Store will automatically re-render it when the state object is changed.
 
 Note: [`Proxy`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) objects are not supported by IE11 (not even with a polyfill), so you need to use the `store.get` and `store.set` methods of the API if you wish to support IE11.
 


### PR DESCRIPTION
After troubleshooting for a long time and not understanding why my component was not rerendered when the state changed, I read through the code.
It turns out `getRenderingRef` of `@stencil/core` only returns truthy when it is currently in a render function.
And the result of `getRenderingRef` is used to mark if a component should be rerendered: https://github.com/ionic-team/stencil-store/blob/17019995f4d6db1c95757e799ef4120261f1c47d/src/subscriptions/stencil.ts#L36

So I just want to save anyone else the time and trouble of finding this by just clarifying it in the readme.