### PR TITLE
fix(66): Let user pass the initial state as a function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ const { reset, state } = createStore(() => ({
   pageA: {
     count: 1
   },
-  pageB {
+  pageB: {
     count: 1
   }
 }));
@@ -110,7 +110,7 @@ const object = {
   pageA: {
     count: 1
   },
-  pageB {
+  pageB: {
     count: 1
   }
 };

--- a/README.md
+++ b/README.md
@@ -77,9 +77,53 @@ const MyGlobalCounter = () => {
 
 ## API
 
-### `createStore<T>(initialState?: T, shouldUpdate?)`
+### `createStore<T>(initialState?: T | (() => T), shouldUpdate?)`
 
 Create a new store with the given initial state. The type is inferred from `initialState`, or can be passed as the generic type `T`.
+`initialState` can be a function that returns the actual initial state. This feature is just in case you have deep objects that mutate
+as otherwise we cannot keep track of those.
+
+```ts
+const { reset, state } = createStore(() => ({
+  pageA: {
+    count: 1
+  },
+  pageB {
+    count: 1
+  }
+}));
+
+state.pageA.count = 2;
+state.pageB.count = 3;
+
+reset();
+
+state.pageA.count; // 1
+state.pageB.count; // 1
+```
+
+Please, bear in mind that the object needs to be created inside the function, not just referenced. The following example won't work
+as you might want it to, as the returned object is always the same one.
+
+```ts
+const object = {
+  pageA: {
+    count: 1
+  },
+  pageB {
+    count: 1
+  }
+};
+const { reset, state } = createStore(() => object);
+
+state.pageA.count = 2;
+state.pageB.count = 3;
+
+reset();
+
+state.pageA.count; // 2
+state.pageB.count; // 3
+```
 
 By default, store performs a exact comparison (`===`) between the new value, and the previous one in order to prevent unnecessary rerenders, however, this behaviour can be changed by providing a `shouldUpdate` function through the second argument. When this function returns `false`, the value won't be updated. By providing a custom `shouldUpdate()` function, applications can create their own fine-grained change detection logic, beyond the default `===`. This may be useful for certain use-cases to avoid any expensive re-rendering.
 

--- a/src/observable-map.test.ts
+++ b/src/observable-map.test.ts
@@ -157,6 +157,67 @@ describe.each([
   }
 );
 
+describe('using a function as initial value', () => {
+  test('function gets invoked', () => {
+    const fn = jest.fn().mockReturnValue({ a: 1 });
+
+    createObservableMap(fn);
+
+    // We should not need to call this more than once
+    // when creating the proxy.
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test('returned value is used as object', () => {
+    const fn = jest.fn().mockReturnValue({ a: 1 });
+
+    const { state } = createObservableMap(fn);
+
+    expect(state).toHaveProperty('a', 1);
+  });
+
+  test('resetting resets deep objects', () => {
+    const fn = () => ({
+      a: {
+        b: 1,
+        c: 2,
+      },
+      d: [1, 2],
+    });
+    const { reset, state } = createObservableMap(fn);
+    state.a.b = 3;
+    state.a.c = 5;
+    state.d.push(1, 2);
+
+    reset();
+
+    expect(state.a).toHaveProperty('b', 1);
+    expect(state.a).toHaveProperty('c', 2);
+    expect(state).toHaveProperty('d', [1, 2]);
+  });
+
+  test('if the function does not create a new object, there is nothing we can do', () => {
+    const object = {
+      a: {
+        b: 1,
+        c: 2,
+      },
+      d: [1, 2],
+    };
+    const fn = () => object;
+    const { reset, state } = createObservableMap(fn);
+    state.a.b = 3;
+    state.a.c = 5;
+    state.d.push(1, 2);
+
+    reset();
+
+    expect(state.a).toHaveProperty('b', 3);
+    expect(state.a).toHaveProperty('c', 5);
+    expect(state).toHaveProperty('d', [1, 2, 1, 2]);
+  });
+});
+
 test('unregister events', () => {
   const { reset, state, on, onChange } = createObservableMap({
     hola: 'hola',

--- a/src/observable-map.ts
+++ b/src/observable-map.ts
@@ -1,10 +1,15 @@
 import { OnHandler, OnChangeHandler, Subscription, ObservableMap, Handlers } from './types';
 
+type Invocable<T> = T | (() => T);
+
+const unwrap = <T>(val: Invocable<T>): T => (typeof val === 'function' ? (val as () => T)() : val);
+
 export const createObservableMap = <T extends { [key: string]: any }>(
-  defaultState?: T,
+  defaultState?: Invocable<T>,
   shouldUpdate: (newV: any, oldValue, prop: keyof T) => boolean = (a, b) => a !== b
 ): ObservableMap<T> => {
-  let states = new Map<string, any>(Object.entries(defaultState ?? {}));
+  const unwrappedState = unwrap(defaultState);
+  let states = new Map<string, any>(Object.entries(unwrappedState ?? {}));
   const handlers: Handlers<T> = {
     dispose: [],
     get: [],
@@ -13,7 +18,7 @@ export const createObservableMap = <T extends { [key: string]: any }>(
   };
 
   const reset = (): void => {
-    states = new Map<string, any>(Object.entries(defaultState ?? {}));
+    states = new Map<string, any>(Object.entries(unwrap(defaultState) ?? {}));
 
     handlers.reset.forEach((cb) => cb());
   };
@@ -43,7 +48,7 @@ export const createObservableMap = <T extends { [key: string]: any }>(
   const state = (
     typeof Proxy === 'undefined'
       ? {}
-      : new Proxy(defaultState, {
+      : new Proxy(unwrappedState, {
           get(_, propName) {
             return get(propName as any);
           },
@@ -79,7 +84,7 @@ export const createObservableMap = <T extends { [key: string]: any }>(
         cb(newValue);
       }
     });
-    const unReset = on('reset', () => cb(defaultState[propName]));
+    const unReset = on('reset', () => cb(unwrap(defaultState)[propName]));
     return () => {
       unSet();
       unReset();

--- a/src/observable-map.ts
+++ b/src/observable-map.ts
@@ -47,31 +47,29 @@ export const createObservableMap = <T extends { [key: string]: any }>(
     }
   };
 
-  const state = (
-    typeof Proxy === 'undefined'
-      ? {}
-      : new Proxy(unwrappedState, {
-          get(_, propName) {
-            return get(propName as any);
-          },
-          ownKeys(_) {
-            return Array.from(states.keys());
-          },
-          getOwnPropertyDescriptor() {
-            return {
-              enumerable: true,
-              configurable: true,
-            };
-          },
-          has(_, propName) {
-            return states.has(propName as any);
-          },
-          set(_, propName, value) {
-            set(propName as any, value);
-            return true;
-          },
-        })
-  ) as T;
+  const state = (typeof Proxy === 'undefined'
+    ? {}
+    : new Proxy(unwrappedState, {
+        get(_, propName) {
+          return get(propName as any);
+        },
+        ownKeys(_) {
+          return Array.from(states.keys());
+        },
+        getOwnPropertyDescriptor() {
+          return {
+            enumerable: true,
+            configurable: true,
+          };
+        },
+        has(_, propName) {
+          return states.has(propName as any);
+        },
+        set(_, propName, value) {
+          set(propName as any, value);
+          return true;
+        },
+      })) as T;
 
   const on: OnHandler<T> = (eventName, callback) => {
     handlers[eventName].push(callback);
@@ -86,6 +84,8 @@ export const createObservableMap = <T extends { [key: string]: any }>(
         cb(newValue);
       }
     });
+    // We need to unwrap the defaultState because it might be a function.
+    // Otherwise we might not be sending the right reset value.
     const unReset = on('reset', () => cb(unwrap(defaultState)[propName]));
     return () => {
       unSet();

--- a/src/observable-map.ts
+++ b/src/observable-map.ts
@@ -18,7 +18,7 @@ export const createObservableMap = <T extends { [key: string]: any }>(
   };
 
   const reset = (): void => {
-    // when resetting the state, the default state may be a function - unwrap it to invoke it.
+    // When resetting the state, the default state may be a function - unwrap it to invoke it.
     // otherwise, the state won't be properly reset
     states = new Map<string, any>(Object.entries(unwrap(defaultState) ?? {}));
 
@@ -47,29 +47,31 @@ export const createObservableMap = <T extends { [key: string]: any }>(
     }
   };
 
-  const state = (typeof Proxy === 'undefined'
-    ? {}
-    : new Proxy(unwrappedState, {
-        get(_, propName) {
-          return get(propName as any);
-        },
-        ownKeys(_) {
-          return Array.from(states.keys());
-        },
-        getOwnPropertyDescriptor() {
-          return {
-            enumerable: true,
-            configurable: true,
-          };
-        },
-        has(_, propName) {
-          return states.has(propName as any);
-        },
-        set(_, propName, value) {
-          set(propName as any, value);
-          return true;
-        },
-      })) as T;
+  const state = (
+    typeof Proxy === 'undefined'
+      ? {}
+      : new Proxy(unwrappedState, {
+          get(_, propName) {
+            return get(propName as any);
+          },
+          ownKeys(_) {
+            return Array.from(states.keys());
+          },
+          getOwnPropertyDescriptor() {
+            return {
+              enumerable: true,
+              configurable: true,
+            };
+          },
+          has(_, propName) {
+            return states.has(propName as any);
+          },
+          set(_, propName, value) {
+            set(propName as any, value);
+            return true;
+          },
+        })
+  ) as T;
 
   const on: OnHandler<T> = (eventName, callback) => {
     handlers[eventName].push(callback);

--- a/src/observable-map.ts
+++ b/src/observable-map.ts
@@ -18,6 +18,8 @@ export const createObservableMap = <T extends { [key: string]: any }>(
   };
 
   const reset = (): void => {
+    // when resetting the state, the default state may be a function - unwrap it to invoke it.
+    // otherwise, the state won't be properly reset
     states = new Map<string, any>(Object.entries(unwrap(defaultState) ?? {}));
 
     handlers.reset.forEach((cb) => cb());


### PR DESCRIPTION
Some users are using stencil-store with deep objects. This is a way
for reset to keep working for them.

Closes #66 