### PR TITLE
chore(github): add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ionic-team/stencil


### PR DESCRIPTION
add a codeowners file to the repo such that any pull request (for any
file in the repo) will require a review/approval from a member of the
stencil github team.