### PR TITLE
chore(github): add ionitron bot to the repo 

### DIFF
--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -1,0 +1,123 @@
+triage:
+  label: triage
+  dryRun: false
+
+closeAndLock:
+  labels:
+    - label: "ionitron: support"
+      message: >
+        Thanks for the issue! This issue appears to be a support request. We use this issue tracker exclusively for
+        bug reports and feature requests. Please use our [slack channel](https://stencil-worldwide.herokuapp.com/)
+        for questions about Stencil.
+
+
+        Thank you for using Stencil!
+    - label: "ionitron: missing template"
+      message: >
+        Thanks for the issue! It appears that you have not filled out the provided issue template. We use this issue
+        template in order to gather more information and further assist you. Please create a new issue and ensure the
+        template is fully filled out.
+
+
+        Thank you for using Stencil!
+  close: true
+  lock: true
+  dryRun: false
+
+comment:
+  labels:
+    - label: "ionitron: needs reproduction"
+      message: >
+        Thanks for the issue! This issue has been labeled as `needs reproduction`. This label is added to issues that
+        need a code reproduction.
+
+
+        Please reproduce this issue in an Stencil starter component library and provide a way for us to access it
+        (GitHub repo, StackBlitz, etc). Without a reliable code reproduction, it is unlikely we will be able to resolve
+        the issue, leading to it being closed.
+
+
+        If you have already provided a code snippet and are seeing this message, it is likely that the code snippet was
+        not enough for our team to reproduce the issue.
+
+
+        For a guide on how to create a good reproduction, see our
+        [Contributing Guide](https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md).
+  dryRun: false
+
+noReply:
+  maxIssuesPerRun: 100
+  includePullRequests: false
+  label: Awaiting Reply
+  close: false
+  lock: false
+  dryRun: false
+
+noReproduction:
+  days: 14
+  maxIssuesPerRun: 100
+  label: "ionitron: needs reproduction"
+  responseLabel: triage
+  exemptProjects: true
+  exemptMilestones: true
+  message: >
+    Thanks for the issue! This issue is being closed due to the lack of a code reproduction. If this is still
+    an issue with the latest version of Stencil, please create a new issue and ensure the template is fully filled out.
+
+
+    Thank you for using Stencil!
+  close: true
+  lock: true
+  dryRun: false
+
+stale:
+  days: 30
+  maxIssuesPerRun: 100
+  exemptLabels:
+    - "Bug: Validated"
+    - "Feature: Want this? Upvote it!"
+    - good first issue
+    - help wanted
+    - Reply Received
+    - Request For Comments
+    - "Resolution: Needs Investigation"
+    - "Resolution: Refine"
+    - triage
+  exemptAssigned: true
+  exemptProjects: true
+  exemptMilestones: true
+  label: "ionitron: stale issue"
+  message: >
+    Thanks for the issue! This issue is being closed due to inactivity. If this is still
+    an issue with the latest version of Stencil, please create a new issue and ensure the
+    template is fully filled out.
+
+
+    Thank you for using Stencil!
+  close: true
+  lock: true
+  dryRun: false
+
+wrongRepo:
+  repos:
+    - label: "ionitron: cli"
+      repo: ionic-cli
+      message: >
+        Thanks for the issue! We use this issue tracker exclusively for bug reports and feature requests
+        associated with Stencil. It appears that this issue is associated with the Ionic CLI.
+        I am moving this issue to the Ionic CLI repository. Please track this issue over there.
+
+
+        Thank you for using Stencil!
+    - label: "ionitron: ionic"
+      repo: ionic
+      message: >
+        Thanks for the issue! We use this issue tracker exclusively for bug reports and feature requests
+        associated with Stencil. It appears that this issue is associated with the Ionic Framework.
+        I am moving this issue to the Ionic Framework repository. Please track this issue over there.
+
+
+        Thank you for using Stencil!
+  close: true
+  lock: true
+  dryRun: false

--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -11,7 +11,7 @@ closeAndLock:
         for questions about Stencil.
 
 
-        Thank you for using Stencil!
+        Thank you for using Stencil Store!
     - label: "ionitron: missing template"
       message: >
         Thanks for the issue! It appears that you have not filled out the provided issue template. We use this issue
@@ -19,7 +19,7 @@ closeAndLock:
         template is fully filled out.
 
 
-        Thank you for using Stencil!
+        Thank you for using Stencil Store!
   close: true
   lock: true
   dryRun: false
@@ -32,9 +32,9 @@ comment:
         need a code reproduction.
 
 
-        Please reproduce this issue in an Stencil starter component library and provide a way for us to access it
-        (GitHub repo, StackBlitz, etc). Without a reliable code reproduction, it is unlikely we will be able to resolve
-        the issue, leading to it being closed.
+        Please reproduce this issue in an Stencil starter component library and Stencil Store. Please provide a way for
+        us to access it (GitHub repo, StackBlitz, etc). Without a reliable code reproduction, it is unlikely we will be
+        able to resolve the issue, leading to it being closed.
 
 
         If you have already provided a code snippet and are seeing this message, it is likely that the code snippet was
@@ -62,10 +62,11 @@ noReproduction:
   exemptMilestones: true
   message: >
     Thanks for the issue! This issue is being closed due to the lack of a code reproduction. If this is still
-    an issue with the latest version of Stencil, please create a new issue and ensure the template is fully filled out.
+    an issue with the latest version of Stencil & Stencil Store, please create a new issue and ensure the template is
+    fully filled out.
 
 
-    Thank you for using Stencil!
+    Thank you for using Stencil Store!
   close: true
   lock: true
   dryRun: false
@@ -93,31 +94,7 @@ stale:
     template is fully filled out.
 
 
-    Thank you for using Stencil!
-  close: true
-  lock: true
-  dryRun: false
-
-wrongRepo:
-  repos:
-    - label: "ionitron: cli"
-      repo: ionic-cli
-      message: >
-        Thanks for the issue! We use this issue tracker exclusively for bug reports and feature requests
-        associated with Stencil. It appears that this issue is associated with the Ionic CLI.
-        I am moving this issue to the Ionic CLI repository. Please track this issue over there.
-
-
-        Thank you for using Stencil!
-    - label: "ionitron: ionic"
-      repo: ionic
-      message: >
-        Thanks for the issue! We use this issue tracker exclusively for bug reports and feature requests
-        associated with Stencil. It appears that this issue is associated with the Ionic Framework.
-        I am moving this issue to the Ionic Framework repository. Please track this issue over there.
-
-
-        Thank you for using Stencil!
+    Thank you for using Stencil Store!
   close: true
   lock: true
   dryRun: false

--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -8,7 +8,7 @@ closeAndLock:
       message: >
         Thanks for the issue! This issue appears to be a support request. We use this issue tracker exclusively for
         bug reports and feature requests. Please use our [slack channel](https://stencil-worldwide.herokuapp.com/)
-        for questions about Stencil.
+        for questions about Stencil Store.
 
 
         Thank you for using Stencil Store!


### PR DESCRIPTION
this commit adds our internal bot 'ionitron' to the create-stencil
repository. technically, ionitron is already configured for the repo,
but needs a configuration file (this commit) to run.

the first commit adds the ionitron configuration from the stencil core
compiler repository at
https://github.com/ionic-team/stencil/blob/b2baf16ec84a944ea567e707bfcde1983e2696ac/.github/ionic-issue-bot.yml.

the next commit then tailors this config to the project