### PR TITLE
chore(github): create dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
this commit adds a dependabot configuration file for opening pull requests
for out of date requests

the idea here is that in order to keep dependencies up to date, have 
Ionitron open PRs for us that we can triage and investigate on a continuous
basis

PS - Opened this to see if the CODEOWNERS file works, it does 🎉 