### PR TITLE
chore(repo): update ci workflow post-stencil v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,17 +13,16 @@ jobs:
     name: (build stencil ${{ matrix.stencil_version }})
     strategy:
       matrix:
-        # Run two different versions in parallel:
+        # Run with multiple different versions of Stencil in parallel:
         # 1. DEFAULT - uses the version of Stencil written in `package-lock.json`, keeping the same version used by the
         # Stencil team as a source of truth
         # 2. 2 - will install the latest release under major version 2 of Stencil. This should be kept as long as this
         # library supports Stencil v2.Y.Z
-        # 3. v4-next - will install a pre-release version of Stencil v4, and is used to detect any regressions in a
-        # pre-release of v4.0.0.
-        # 4. latest - will install the latest version of Stencil. Prior to the Stencil v4.0.0 release, this will
-        # resolve to the latest version of Stencil v3. After the Stencil v4.0.0 release, it will resolve to the latest
-        # version of Stencil v4.
-        stencil_version: ['DEFAULT', '2', 'v4-next', 'latest']
+        # 3. 3 - will install the latest release under major version 3 of Stencil. This should be kept as long as this
+        # library supports Stencil v3.Y.Z
+        # 4. 4 - will install the latest release under major version 4 of Stencil. This should be kept as long as this
+        # library supports Stencil v4.Y.Z
+        stencil_version: ['DEFAULT', '2', '3', '4']
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): CI


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We had certain configs added to the repo's CI for Stencil v4 dev that we no longer need

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates the stencil version matrix in the main ci workflow to:
- no longer use "latest" and "v4-next", now that stencil v4 is out
- explicitly run with stencil v3, v4

as a result, we should expect four runs of this workflow to run in parallel - one for stencil v2, v3, & v4, as well as  one for the version of stencil that is installed in package-lock.json. there is expected to be some overlap between the latest two major versions and "latest" (the latter will point to either v3 or v4, depending on the state of the repo)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->
CI should continue to pass
## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Will have to update gating on CI as a part of this PR