### PR TITLE
fix(types): update default state typings for createStore()

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -3,7 +3,7 @@ import { createObservableMap } from './observable-map';
 import { ObservableMap } from './types';
 
 export const createStore = <T extends { [key: string]: any }>(
-  defaultState?: T,
+  defaultState?: T | (() => T),
   shouldUpdate?: (newV: any, oldValue, prop: keyof T) => boolean,
 ): ObservableMap<T> => {
   const map = createObservableMap(defaultState, shouldUpdate);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A
In Stencil store main README page, it recommends to use anonymous function to return object data type for initial load. But when I use that recommendation in my project, it errors out. It turns out the types of the `createStore` function doesn't have the proper type as written in the docs. I need to patch stencil/store package for a long time in my project just to update types for `store.d.ts` to fix this typing error.
Below is the link to the docs:
https://github.com/ionic-team/stencil-store?tab=readme-ov-file#createstoretinitialstate-t----t-shouldupdate   
And here is current types for the `createStore` function:
<img width="354" alt="image" src="https://github.com/ionic-team/stencil-store/assets/17950626/664209d7-cf74-4b9e-9294-f01f36468f7b">
And here is the error when I tried to use it:
![image](https://github.com/ionic-team/stencil-store/assets/17950626/94c01011-2ce5-4574-8068-dafb2b9cdb13)


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Using `createStore` with anonymous function would not error out
- `defaultState` types of the `createStore` would match with what was written in the docs. 
<img width="359" alt="image" src="https://github.com/ionic-team/stencil-store/assets/17950626/afc159ba-4ef7-4f5a-88ab-062ac6c592df">


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->
- I've been using stencil store in my project for a long time. I forked this stencil store project, changed the types of `store.ts` and built it, installed that bundled package locally. Ran `tsc` for type checking, no errors found on my current project.
- The patch file that's working on my project
![image](https://github.com/ionic-team/stencil-store/assets/17950626/eedbe150-e5e4-40ea-965f-0429c4fab701)
- The declaration version of `store.ts` after running build command:
<img width="577" alt="image" src="https://github.com/ionic-team/stencil-store/assets/17950626/6403ccb9-d7ec-4bd0-87be-12b3e68bd295">


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
N/A